### PR TITLE
Raise help if execute doesn't receive a command.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 dist/
 .tox/
 docs/_build/
+build/

--- a/bespin/tasks.py
+++ b/bespin/tasks.py
@@ -28,6 +28,7 @@ import logging
 import base64
 import shlex
 import json
+import sys
 import os
 
 log = logging.getLogger("bespin.tasks")
@@ -153,6 +154,10 @@ def execute(collector, configuration, **kwargs):
     """Exec a command using assumed credentials"""
     parts = shlex.split(configuration["$@"])
     configuration["bespin"].credentials.verify_creds()
+    if not parts:
+        suggestion = " ".join(sys.argv) + " -- /bin/command_to_run"
+        msg = "No command was provided. Try something like:\n\t\t{0}".format(suggestion)
+        raise BespinError(msg)
     os.execvpe(parts[0], parts, os.environ)
 
 @a_task(needs_credentials=True, needs_stack=True)


### PR DESCRIPTION
It used to fail and didn't offer much help when "parts" was an empty array.
