### PR TITLE
bespin development docs update

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,7 +8,8 @@ request in the issue tracker.
 
 Setting up for development can be as simple as::
 
-  $ pip install virtualenvtools
+  $ pip install virtualenvtools virtualenvwrapper
+  $ source `which virtualenvwrapper.sh`
   $ mkvirtualenv bespin
   $ pip install -e .
   $ pip install -e ".[tests]"


### PR DESCRIPTION
Extra commands I required to get `mkvirtualenv` to work. Regular python devs probably have something like this in their profile.