### PR TITLE
Verify AWS account id via sts:GetCallerIdentity

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
       , "radssh==1.0.5"
       , "pyrelic==0.8.0"
       , "boto==2.40.0"
-      , "boto3==1.2.3"
+      , "boto3"
       , "pyYaml==3.10"
       , "ultra_rest_client==0.1.4"
       , "FileChunkIO==1.6"


### PR DESCRIPTION
Addresses #12 using boto3 and sts:GetCallerIdentity. boto, being deprecated, was never updated to include this API. 

The code already requires boto3, but does not seem to use it anywhere. A separate issue should be raised to migrate to boto3.

This change would introduce a problem that it would verify the accountid using an alternative authenticator (boto3) than the one used to call AWS (boto). One example of this is that boto3/botocore natively supports profiles, where boto does not.