### PR TITLE
AttributeError when tags empty

### DIFF
--- a/bespin/option_spec/stack_objs.py
+++ b/bespin/option_spec/stack_objs.py
@@ -249,7 +249,7 @@ class Stack(dictobj):
                 log.info("Would use following stack from {0}".format(self.stack_json))
                 print(json.dumps(self.stack_json_obj))
             else:
-                return self.cloudformation.create(self.stack_json_obj, self.params_json_obj, self.tags.as_dict() or None)
+                return self.cloudformation.create(self.stack_json_obj, self.params_json_obj, self.tags.as_dict() if self.tags else None)
         elif status.complete:
             log.info("Found existing stack, doing an update")
             if self.bespin.dry_run:


### PR DESCRIPTION
When tags is empty or undefined it defaults to '{}', but when defined it is a MergedOptions().
```
  File "/Users/adamward/git/wha/git/bespin/bespin/option_spec/stack_objs.py", line 259, in create_or_update
    return self.cloudformation.create(self.stack_obj, self.params_json_obj, self.tags.as_dict() or None)
AttributeError: 'dict' object has no attribute 'as_dict'
```
Corrected 'or None' logic with ternary.