### PR TITLE
environment.account_id can be an integer

### DIFF
--- a/bespin/option_spec/bespin_specs.py
+++ b/bespin/option_spec/bespin_specs.py
@@ -7,7 +7,7 @@ The specifications are responsible for sanitation, validation and normalisation.
 
 from input_algorithms.spec_base import (
       formatted, defaulted, any_spec, dictionary_spec, dictof, listof, required, delayed
-    , string_spec, overridden, boolean, file_spec, optional_spec, integer_spec, or_spec, container_spec
+    , string_spec, overridden, boolean, file_spec, optional_spec, integer_spec, or_spec, and_spec, container_spec
     , valid_string_spec, create_spec, string_choice_spec, Spec, always_same_spec, match_spec
     )
 
@@ -176,7 +176,7 @@ class BespinSpec(object):
     def environment_spec(self):
         """Spec for each environment"""
         return create_spec(Environment
-            , account_id = required(or_spec(string_spec(), valid_string_spec(validators.regexed("\d+"))))
+            , account_id = required(or_spec(and_spec(string_spec(), valid_string_spec(validators.regexed("\d+"))), integer_spec()))
             , region = defaulted(string_spec(), "ap-southeast-2")
             , vars = dictionary_spec()
             )

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -110,11 +110,13 @@ describe BespinCase, "Collecting configuration":
             self.assertEqual(stack.vars()["one"].resolve(), '2')
 
     it "converts environments":
-        config = self.make_config({"environments": {"dev": {"account_id": "1231434"}, "staging": {"account_id": "087089", "vars": {"one": "ONE"}}}})
+        config = self.make_config({"environments": {"dev": {"account_id": "1231434"}, "staging": {"account_id": 87089, "vars": {"one": "ONE"}}}})
         with self.make_collector(config, activate_converters=True) as collector:
             environment = collector.configuration["environments"]
             self.assertEqual(type(environment["dev"]), Environment)
             self.assertEqual(environment["dev"].account_id, "1231434")
-            self.assertEqual(environment["staging"].account_id, "087089")
+            self.assertEqual(type(environment["dev"].account_id), str)
+            self.assertEqual(environment["staging"].account_id, 87089)
+            self.assertEqual(type(environment["staging"].account_id), int)
             self.assertEqual(environment["staging"].vars.as_dict(), {"one": "ONE"})
 


### PR DESCRIPTION
As per existing documentation