### PR TITLE
Migrate the core of bespin to boto3

### DIFF
--- a/bespin/amazon/cloudformation.py
+++ b/bespin/amazon/cloudformation.py
@@ -70,14 +70,18 @@ for kls in [Status] + Status.__subclasses__():
 
 ##BOTO3 TODO: refactor to use boto3 resources
 class Cloudformation(AmazonMixin):
-    def __init__(self, stack_name, region="ap-southeast-2"):
+    def __init__(self, stack_name, region="ap-southeast-2", session=None):
         self.region = region
         self.stack_name = stack_name
+        self.session = session
+        if self.session is None:
+            self.session = boto3.session.Session(region_name=self.region)
+        assert self.session.region_name == self.region
 
     @hp.memoized_property
     def conn(self):
         log.info("Using region [%s] for cloudformation (%s)", self.region, self.stack_name)
-        return boto3.client('cloudformation', region_name=self.region)
+        return self.session.client('cloudformation', region_name=self.region)
 
     def reset(self):
         self._description = None

--- a/bespin/amazon/cloudformation.py
+++ b/bespin/amazon/cloudformation.py
@@ -70,18 +70,18 @@ for kls in [Status] + Status.__subclasses__():
 
 ##BOTO3 TODO: refactor to use boto3 resources
 class Cloudformation(AmazonMixin):
-    def __init__(self, stack_name, region="ap-southeast-2", session=None):
+    def __init__(self, stack_name, region="ap-southeast-2"):
         self.region = region
         self.stack_name = stack_name
-        self.session = session
-        if self.session is None:
-            self.session = boto3.session.Session(region_name=self.region)
-        assert self.session.region_name == self.region
 
     @hp.memoized_property
     def conn(self):
         log.info("Using region [%s] for cloudformation (%s)", self.region, self.stack_name)
         return self.session.client('cloudformation', region_name=self.region)
+
+    @hp.memoized_property
+    def session(self):
+        return boto3.session.Session(region_name=self.region)
 
     def reset(self):
         self._description = None

--- a/bespin/amazon/cloudformation.py
+++ b/bespin/amazon/cloudformation.py
@@ -2,9 +2,11 @@ from bespin.errors import StackDoesntExist, BadStack, Throttled
 from bespin.amazon.mixin import AmazonMixin
 from bespin import helpers as hp
 
-import boto.cloudformation
+import botocore
+import boto3
 import datetime
 import logging
+import pytz
 import time
 import six
 import os
@@ -58,11 +60,15 @@ class UPDATE_ROLLBACK_FAILED(Status): pass
 class UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS(Status): pass
 class UPDATE_ROLLBACK_COMPLETE(Status): pass
 
+# REVIEW_IN_PROGRESS only valid for CreateChangeSet with ChangeSetType=CREATE
+class REVIEW_IN_PROGRESS(Status): pass
+
 for kls in [Status] + Status.__subclasses__():
     with_meta = six.add_metaclass(StatusMeta)(kls)
     locals()[kls.__name__] = with_meta
     Status.statuses[kls.__name__] = with_meta
 
+##BOTO3 TODO: refactor to use boto3 resources
 class Cloudformation(AmazonMixin):
     def __init__(self, stack_name, region="ap-southeast-2"):
         self.region = region
@@ -71,7 +77,7 @@ class Cloudformation(AmazonMixin):
     @hp.memoized_property
     def conn(self):
         log.info("Using region [%s] for cloudformation (%s)", self.region, self.stack_name)
-        return boto.cloudformation.connect_to_region(self.region)
+        return boto3.client('cloudformation', region_name=self.region)
 
     def reset(self):
         self._description = None
@@ -83,7 +89,8 @@ class Cloudformation(AmazonMixin):
                 while True:
                     try:
                         with self.ignore_throttling_error():
-                            self._description = self.conn.describe_stacks(self.stack_name)[0]
+                            response = self.conn.describe_stacks(StackName=self.stack_name)
+                            self._description = response['Stacks'][0]
                             break
                     except Throttled:
                         log.info("Was throttled, waiting a bit")
@@ -94,10 +101,10 @@ class Cloudformation(AmazonMixin):
     def outputs(self):
         self.wait()
         description = self.description()
-        if description is None:
-            return {}
+        if 'Outputs' in description.outputs:
+            return dict((out['OutputKey'], out['OutputValue']) for out in description['Outputs'])
         else:
-            return dict((out.key, out.value) for out in description.outputs)
+            return {}
 
     @property
     def status(self):
@@ -113,30 +120,32 @@ class Cloudformation(AmazonMixin):
 
         try:
             description = self.description(force=force)
-            return Status.find(description.stack_status)
+            return Status.find(description['StackStatus'])
         except StackDoesntExist:
             return NONEXISTANT
 
     def map_logical_to_physical_resource_id(self, logical_id):
-        resource = self.conn.describe_stack_resource(stack_name_or_id=self.stack_name, logical_resource_id=logical_id)
-        return resource['DescribeStackResourceResponse']['DescribeStackResourceResult']['StackResourceDetail']["PhysicalResourceId"]
+        response = self.conn.describe_stack_resource(StackName=self.stack_name, LogicalResourceId=logical_id)
+        return response['StackResourceDetail']["PhysicalResourceId"]
+
+    def _convert_tags(self, tags):
+        """ helper to convert python dictionary into list of AWS Tag dicts """
+        return [{'Key': k, 'Value': v} for k,v in tags.items()] if tags else None
 
     def create(self, stack, params, tags):
         log.info("Creating stack (%s)\ttags=%s", self.stack_name, tags)
-        params = [(param["ParameterKey"], param["ParameterValue"]) for param in params] if params else None
         disable_rollback = os.environ.get("DISABLE_ROLLBACK", 0) == "1"
-        self.conn.create_stack(self.stack_name, template_body=stack, parameters=params, tags=tags, capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'], disable_rollback=disable_rollback)
+        self.conn.create_stack(StackName=self.stack_name, TemplateBody=stack, Parameters=params, Tags=self._convert_tags(tags), Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'], DisableRollback=disable_rollback)
         return True
 
-    def update(self, stack, params):
+    def update(self, stack, params, tags):
         log.info("Updating stack (%s)", self.stack_name)
-        params = [(param["ParameterKey"], param["ParameterValue"]) for param in params] if params else None
-        disable_rollback = os.environ.get("DISABLE_ROLLBACK", 0) == "1"
+        # NOTE: DisableRollback is not supported by UpdateStack. It is a property of the stack that can only be set during stack creation
         with self.catch_boto_400(BadStack, "Couldn't update the stack", stack_name=self.stack_name):
             try:
-                self.conn.update_stack(self.stack_name, template_body=stack, parameters=params, capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'], disable_rollback=disable_rollback)
-            except boto.exception.BotoServerError as error:
-                if error.message == "No updates are to be performed.":
+                self.conn.update_stack(StackName=self.stack_name, TemplateBody=stack, Parameters=params, Tags=self._convert_tags(tags), Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'])
+            except botocore.exceptions.ClientError as error:
+                if error.response['Error']['Message'] == "No updates are to be performed.":
                     log.info("No updates were necessary!")
                     return False
                 else:
@@ -145,14 +154,16 @@ class Cloudformation(AmazonMixin):
 
     def validate_template(self, filename):
         with self.catch_boto_400(BadStack, "Amazon says no", stack_name=self.stack_name, filename=filename):
-            self.conn.validate_template(open(filename).read())
+            self.conn.validate_template(TemplateBody=open(filename).read())
 
+    ##BOTO3 TODO: can this be refactored with client.get_waiter?
+    ##BOTO3 TODO: also consider client.get_paginator('describe_stack_events')
     def wait(self, timeout=1200, rollback_is_failure=False, may_not_exist=True):
         status = self.status
         if not status.exists and may_not_exist:
             return status
 
-        last = datetime.datetime.utcnow()
+        last = datetime.datetime.now(pytz.utc)
         if status.failed:
             raise BadStack("Stack is in a failed state, it must be deleted first", name=self.stack_name, status=status)
 
@@ -172,17 +183,18 @@ class Cloudformation(AmazonMixin):
             while True:
                 try:
                     with self.ignore_throttling_error():
-                        events = description.describe_events()
+                        response = self.conn.describe_stack_events(StackName=self.stack_name)
+                        events = response['StackEvents']
                         break
                 except Throttled:
                     log.info("Was throttled, waiting a bit")
                     time.sleep(1)
 
-            next_last = events[0].timestamp
+            next_last = events[0]['Timestamp']
             for event in events:
-                if event.timestamp > last:
-                    reason = event.resource_status_reason or ""
-                    log.info("%s - %s %s (%s) %s", self.stack_name, event.resource_type, event.logical_resource_id, event.resource_status, reason)
+                if event['Timestamp'] > last:
+                    reason = event['ResourceStatusReason'] or ""
+                    log.info("%s - %s %s (%s) %s", self.stack_name, event['ResourceType'], event['LogicalResourceId'], event['ResourceStatus'], reason)
             last = next_last
 
         status = self.status

--- a/bespin/amazon/credentials.py
+++ b/bespin/amazon/credentials.py
@@ -5,15 +5,10 @@ from bespin.amazon.ec2 import EC2
 from bespin.amazon.sqs import SQS
 from bespin.amazon.kms import KMS
 from bespin.amazon.s3 import S3
-
-import boto.sts
-import boto.iam
-import boto.s3
-import boto.sqs
+from bespin import VERSION
 
 from input_algorithms.spec_base import NotSpecified
 import logging
-import boto
 import botocore
 import boto3
 import os
@@ -25,6 +20,7 @@ class Credentials(object):
         self.region = region
         self.account_id = account_id
         self.assume_role = assume_role
+        self.session = None
         self.clouds = {}
 
     def verify_creds(self):
@@ -39,7 +35,8 @@ class Credentials(object):
 
         log.info("Verifying amazon credentials")
         try:
-            amazon_account_id = boto3.client('sts').get_caller_identity().get('Account')
+            self.session = boto3.session.Session(region_name=self.region)
+            amazon_account_id = self.session.client('sts').get_caller_identity().get('Account')
             if int(self.account_id) != int(amazon_account_id):
                 raise BespinError("Please use credentials for the right account", expect=self.account_id, got=amazon_account_id)
             self._verified = True
@@ -47,6 +44,8 @@ class Credentials(object):
             raise BespinError("Export AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY before running this script (your aws credentials)")
         except botocore.exceptions.ClientError as error:
             raise BespinError("Couldn't determine what account your credentials are from", error=error.message)
+
+        assert self.session is not None and self.session.region_name == self.region
 
 
     def assume(self):
@@ -58,24 +57,28 @@ class Credentials(object):
                 del os.environ[name]
 
         try:
-            conn = boto.sts.connect_to_region(self.region)
-        except boto.exception.NoAuthHandlerFound:
+            conn = boto3.client('sts', region_name=self.region)
+            session_name = "{1}@bespin{0}".format(VERSION, os.environ.get("USER", "<unknown_user>"))
+            response = conn.assume_role(RoleArn=assumed_role, RoleSessionName=session_name)
+
+            role = response['AssumedRoleUser']
+            creds = response['Credentials']
+            log.info("Assumed role (%s)", role['Arn'])
+            self.session = boto3.session.Session(
+                    aws_access_key_id=creds['AccessKeyId'],
+                    aws_secret_access_key=creds['SecretAccessKey'],
+                    aws_session_token=creds['SessionToken'],
+                    region_name=self.region
+            )
+
+            os.environ['AWS_ACCESS_KEY_ID'] = creds["AccessKeyId"]
+            os.environ['AWS_SECRET_ACCESS_KEY'] = creds["SecretAccessKey"]
+            os.environ['AWS_SECURITY_TOKEN'] = creds["SessionToken"]
+            os.environ['AWS_SESSION_TOKEN'] = creds["SessionToken"]
+        except botocore.exceptions.NoCredentialsError:
             raise BespinError("Export AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY before running this script (your aws credentials)")
-
-        try:
-            creds = conn.assume_role(assumed_role, "bespin")
-        except boto.exception.BotoServerError as error:
-            if error.status == 403:
-                raise BespinError("Not allowed to assume role", error=error.message)
-            else:
-                raise
-
-        creds_dict = creds.credentials.to_dict()
-
-        os.environ['AWS_ACCESS_KEY_ID'] = creds_dict["access_key"]
-        os.environ['AWS_SECRET_ACCESS_KEY'] = creds_dict["secret_key"]
-        os.environ['AWS_SECURITY_TOKEN'] = creds_dict["session_token"]
-        os.environ['AWS_SESSION_TOKEN'] = creds_dict["session_token"]
+        except botocore.exceptions.ClientError as error:
+            raise BespinError("Unable to assume role", error=error.message)
 
     @memoized_property
     def s3(self):
@@ -101,11 +104,11 @@ class Credentials(object):
     def iam(self):
         self.verify_creds()
         log.info("Using region [%s] for iam", self.region)
-        return boto.iam.connect_to_region(self.region)
+        return self.session.client('iam', region_name=self.region)
 
     def cloudformation(self, stack_name):
         self.verify_creds()
         if stack_name not in self.clouds:
-            self.clouds[stack_name] = Cloudformation(stack_name, self.region)
+            self.clouds[stack_name] = Cloudformation(stack_name, self.region, self.session)
         return self.clouds[stack_name]
 

--- a/bespin/amazon/mixin.py
+++ b/bespin/amazon/mixin.py
@@ -2,20 +2,21 @@ from bespin.errors import Throttled
 
 from contextlib import contextmanager
 import logging
-import boto
+import botocore
 
 log = logging.getLogger("bespin.amazon.mixin")
 
 class AmazonMixin(object):
     @contextmanager
     def catch_boto_400(self, errorkls, message, **info):
-        """Turn a BotoServerError 400 into a BadAmazon"""
+        """Turn a boto HTTP 400 into a BadAmazon"""
         try:
             yield
-        except boto.exception.BotoServerError as error:
-            if error.status == 400:
-                log.error("%s -(%s)- %s", message, error.code, error.message)
-                raise errorkls(message, error_code=error.code, error_message=error.message, **info)
+        except botocore.exceptions.ClientError as error:
+            code = error.response['ResponseMetadata']['HTTPStatusCode']
+            if code == 400:
+                log.error("%s -(%s)- %s", message, code, error.message)
+                raise errorkls(message, error_code=code, error_message=error.message, **info)
             else:
                 raise
 
@@ -23,8 +24,8 @@ class AmazonMixin(object):
     def ignore_throttling_error(self):
         try:
             yield
-        except boto.exception.BotoServerError as error:
-            if error.status == 400 and error.code == "Throttling":
+        except botocore.exceptions.ClientError as error:
+            if error.response['Error']['Code'] == 'Throttling':
                 raise Throttled()
             else:
                 raise

--- a/bespin/option_spec/stack_objs.py
+++ b/bespin/option_spec/stack_objs.py
@@ -252,6 +252,9 @@ class Stack(dictobj):
         """Create or update the stack, return True if the stack actually changed"""
         log.info("Creating or updating the stack (%s)", self.stack_name)
         status = self.cloudformation.wait(may_not_exist=True)
+        tags = self.tags or None
+        if tags and type(tags) is not dict and hasattr(self.tags, "as_dict"):
+            tags = tags.as_dict()
 
         if not status.exists:
             log.info("No existing stack, making one now")
@@ -260,9 +263,6 @@ class Stack(dictobj):
                 log.info("Would use following stack from {0}".format(self.stack_json))
                 print(self.dumped_stack_obj)
             else:
-                tags = self.tags or None
-                if tags and type(tags) is not dict and hasattr(self.tags, "as_dict"):
-                    tags = tags.as_dict()
                 return self.cloudformation.create(self.dumped_stack_obj, self.params_json_obj, tags)
         elif status.complete:
             log.info("Found existing stack, doing an update")
@@ -271,7 +271,7 @@ class Stack(dictobj):
                 log.info("Would use following stack from {0}".format(self.stack_json))
                 print(json.dumps(self.dumped_stack_obj))
             else:
-                return self.cloudformation.update(self.dumped_stack_obj, self.params_json_obj)
+                return self.cloudformation.update(self.dumped_stack_obj, self.params_json_obj, tags)
         else:
             raise BadStack("Stack could not be updated", name=self.stack_name, status=status.name)
 


### PR DESCRIPTION
Migrate `bespin.amazon.credentials` and `bespin.amazon.cloudformation` to use boto3 (#17). This migrates what I consider the core of bespin (environments & stacks).

Untouched modules (`bespin.amazon.ec2`, `s3`, `sqs`, `kms`) will continue to operate using the boto authenticator off either the user's environment, or the overlaid `assume_role` environment.
The migration of the remaining modules will be done in separate PRs and will be tracked in #17.