### PR TITLE
Update link to build status

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,8 @@ Bespin
 An opinionated wrapper around Amazon Cloudformation that reads yaml files.
 and make things happen.
 
-.. image:: https://travis-ci.org/realestate-com-au/bespin.png?branch=master
-    :target: https://travis-ci.org/realestate-com-au/bespin
+.. image:: https://travis-ci.org/delfick/bespin.png?branch=master
+    :target: https://travis-ci.org/delfick/bespin
 
 The documentation can be found at http://bespin.readthedocs.io
 

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -67,6 +67,8 @@ if sys.version.startswith('3'): sys.exit(1)
   source $TMP_DIR/bin/activate
   pip install -r sphinx/requirements.txt
 fi
+
+set -e
 
 # use with --clean if you change anything in sphinx
 if (($CLEAN==1)); then


### PR DESCRIPTION
docs builder also fails with '-e' due to `-d sphinx/venv` from clean repo. Moved to `set -e` before actual work. 