### PR TITLE
Update docs for extra_imports

### DIFF
--- a/docs/docs/tasks.rst
+++ b/docs/docs/tasks.rst
@@ -57,7 +57,8 @@ And your bespin.yml looked like::
   ---
 
   bespin:
-    extra_imports: ["{config_root}", "scripts"]
+    extra_imports:
+    - ["{config_root}", "scripts"]
 
   stacks:
     app:


### PR DESCRIPTION
takes list of imports, ie:
	`extra_imports = listof(imports.import_spec())`
	`[[dir, module], ...]`

obvious fix