### PR TITLE
Do not merge extra_files over main bespin.yml

### DIFF
--- a/bespin/collector.py
+++ b/bespin/collector.py
@@ -114,15 +114,16 @@ class Collector(Collector):
 
     def add_configuration(self, configuration, collect_another_source, done, result, src):
         """Used to add a file to the configuration, result here is the yaml.load of the src"""
-        configuration.update(result, dont_prefix=[dictobj], source=src)
-
-        if "bespin" in configuration:
-            if "extra_files" in configuration.get("bespin", {}, ignore_converters=True):
-                for extra in sb.listof(sb.formatted(sb.string_spec(), formatter=MergedOptionStringFormatter)).normalise(Meta(configuration, [("bespin", ""), ("extra_files", "")]), configuration["bespin"]["extra_files"]):
+        if "bespin" in result:
+            if "extra_files" in result.get("bespin", {}):
+                for extra in sb.listof(sb.formatted(sb.string_spec(), formatter=MergedOptionStringFormatter)).normalise(Meta(configuration, [("bespin", ""), ("extra_files", "")]), result["bespin"]["extra_files"]):
+                    extra = os.path.join(result['config_root'], extra)
                     if os.path.abspath(extra) not in done:
                         if not os.path.exists(extra):
                             raise BadConfiguration("Specified extra file doesn't exist", extra=extra, source=src)
                         collect_another_source(extra)
+
+        configuration.update(result, dont_prefix=[dictobj], source=src)
 
     def extra_configuration_collection(self, configuration):
         """Hook to do any extra configuration collection or converter registration"""


### PR DESCRIPTION
Currently the collector adds bespin.yml configuration and then merges
extra_files over the top (in order). This functionality is counter
intuitive to new users as the primary configuration should be a source
of truth. YAML entries defined in the primary configuration should
override all others.

Change the load of additional configuration files (if specified) to
happen prior to the main bespin.yml