### PR TITLE
Allow assume_role to be specified shorthand

### DIFF
--- a/bespin/amazon/credentials.py
+++ b/bespin/amazon/credentials.py
@@ -48,9 +48,16 @@ class Credentials(object):
         if self.session is None or self.session.region_name != self.region:
             raise ProgrammerError("botocore.session created in incorrect region")
 
+    def account_role_arn(self, role, partition='aws'):
+        """Return full ARN for a role within the current account"""
+        if not role or role.startswith("arn:aws"):
+            return role
+        if not role.startswith("role/"):
+            role = "role/" + role
+        return "arn:{0}:iam::{1}:{2}".format(partition, self.account_id, role)
 
     def assume(self):
-        assumed_role = "arn:aws:iam::{0}:{1}".format(self.account_id, self.assume_role)
+        assumed_role = self.account_role_arn(self.assume_role)
         log.info("Assuming role as %s", assumed_role)
 
         for name in ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SECURITY_TOKEN', 'AWS_SESSION_TOKEN']:


### PR DESCRIPTION
Current configuration requires 'role/role_name'. This extends that
to also take the short name and automatically prefix 'role/' if needed.

Additionally if role looks like ARN it is left as is for power users.
Also abstracts out AWS partition for potential future porting for aws-cn or aws-us-gov

Hangs off/depends on merge of #17 