### PR TITLE
Add support for CF RoleARN

### DIFF
--- a/bespin/amazon/cloudformation.py
+++ b/bespin/amazon/cloudformation.py
@@ -136,7 +136,7 @@ class Cloudformation(AmazonMixin):
         """ helper to convert python dictionary into list of AWS Tag dicts """
         return [{'Key': k, 'Value': v} for k,v in tags.items()] if tags else None
 
-    def create(self, stack, params, tags=None, policy=None):
+    def create(self, stack, params, tags=None, policy=None, role_arn=None):
         log.info("Creating stack (%s)\ttags=%s", self.stack_name, tags)
         stack_args = {
               'StackName': self.stack_name
@@ -147,10 +147,11 @@ class Cloudformation(AmazonMixin):
             , 'DisableRollback': os.environ.get("DISABLE_ROLLBACK", 0) == "1"
         }
         if policy: stack_args['StackPolicyBody'] = policy
+        if role_arn: stack_args['RoleARN'] = role_arn
         self.conn.create_stack(**stack_args)
         return True
 
-    def update(self, stack, params, tags=None, policy=None):
+    def update(self, stack, params, tags=None, policy=None, role_arn=None):
         log.info("Updating stack (%s)", self.stack_name)
         stack_args = {
               'StackName': self.stack_name
@@ -161,6 +162,7 @@ class Cloudformation(AmazonMixin):
             # NOTE: DisableRollback is not supported by UpdateStack. It is a property of the stack that can only be set during stack creation
         }
         if policy: stack_args['StackPolicyBody'] = policy
+        if role_arn: stack_args['RoleARN'] = role_arn
         with self.catch_boto_400(BadStack, "Couldn't update the stack", stack_name=self.stack_name):
             try:
                 self.conn.update_stack(**stack_args)

--- a/bespin/option_spec/bespin_specs.py
+++ b/bespin/option_spec/bespin_specs.py
@@ -306,6 +306,7 @@ class BespinSpec(object):
             , params_yaml = valid_params_yaml(default="{config_root}/{environment}/{_key_name_1}-params.yaml")
 
             , stack_policy = valid_policy_json(default="{config_root}/{_key_name_1}-policy.json")
+            , role_name = formatted(string_spec(), formatter=MergedOptionStringFormatter)
 
             , build_first = listof(formatted(string_spec(), formatter=MergedOptionStringFormatter))
             , build_after = listof(formatted(string_spec(), formatter=MergedOptionStringFormatter))


### PR DESCRIPTION
Add support to specify `role_name` on a stack. This is the role that CloudFormation will assume when creating and updating the stack, and differs in functionality from `assume_role` which is the user(role) requesting `CreateStack` or `UpdateStack`.