### PR TITLE
Making {:this_config_dir} give the location of that config

### DIFF
--- a/bespin/formatter.py
+++ b/bespin/formatter.py
@@ -19,6 +19,7 @@ from bespin.errors import BadOptionFormat
 from input_algorithms.meta import Meta
 
 from datetime import datetime
+import os
 
 class MergedOptionStringFormatter(StringFormatter):
     """
@@ -61,7 +62,7 @@ class MergedOptionStringFormatter(StringFormatter):
 
     def special_get_field(self, value, args, kwargs, format_spec=None):
         """Also take the spec into account"""
-        if format_spec in ("env", "underscored", "date"):
+        if format_spec in ("env", "underscored", "date", "this_config_dir"):
             return value, ()
 
         if value in self.chain:
@@ -78,3 +79,8 @@ class MergedOptionStringFormatter(StringFormatter):
         elif format_spec == "date":
             return datetime.now().strftime(obj)
 
+        elif format_spec == "this_config_dir":
+            sources = self.all_options.source_for(self.option_path)
+            if not sources:
+                raise BadOptionFormat("Couldn't find this_config_dir for the option", option_path=self.option_path)
+            return os.path.normpath(os.path.dirname(sources[0]))

--- a/bespin/formatter.py
+++ b/bespin/formatter.py
@@ -62,7 +62,7 @@ class MergedOptionStringFormatter(StringFormatter):
 
     def special_get_field(self, value, args, kwargs, format_spec=None):
         """Also take the spec into account"""
-        if format_spec in ("env", "underscored", "date", "this_config_dir"):
+        if format_spec in ("env", "underscored", "date", "config_dir"):
             return value, ()
 
         if value in self.chain:
@@ -79,8 +79,11 @@ class MergedOptionStringFormatter(StringFormatter):
         elif format_spec == "date":
             return datetime.now().strftime(obj)
 
-        elif format_spec == "this_config_dir":
-            sources = self.all_options.source_for(self.option_path)
+        elif format_spec == "config_dir":
+            path = self.option_path
+            if obj:
+                path = obj
+            sources = self.all_options.source_for(path)
             if not sources:
-                raise BadOptionFormat("Couldn't find this_config_dir for the option", option_path=self.option_path)
+                raise BadOptionFormat("Couldn't find config_dir for the option", option_path=self.option_path)
             return os.path.normpath(os.path.dirname(sources[0]))

--- a/bespin/option_spec/bespin_specs.py
+++ b/bespin/option_spec/bespin_specs.py
@@ -36,7 +36,7 @@ class valid_params(Spec):
     def setup(self, default):
         self.dflt = default
 
-    def normalise_either(self, meta, val):
+    def normalise(self, meta, val):
         if isinstance(val, six.string_types) or val is NotSpecified:
             val = formatted(defaulted(string_spec(), self.dflt), formatter=MergedOptionStringFormatter).normalise(meta, val)
             if os.path.exists(val):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
 
     , install_requires =
       [ "delfick_app==0.9.3"
-      , "option_merge==1.4.4"
+      , "option_merge==1.5"
       , "input_algorithms==0.5.9"
 
       , "six"

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -121,7 +121,7 @@ describe BespinCase, "Collecting configuration":
             self.assertEqual(type(environment["staging"].account_id), int)
             self.assertEqual(environment["staging"].vars.as_dict(), {"one": "ONE"})
 
-    it "allows the special this_config_root formatter option to produce the config file where the option is defined":
+    it "allows the special config_dir formatter option to produce the config file where the option is defined":
         if sys.version.startswith("2.6."):
             raise nose.SkipTest("Can't have a zero length format field in python2.6")
 
@@ -136,7 +136,7 @@ describe BespinCase, "Collecting configuration":
 
 
         vars:
-            b_pointer: "{:this_config_dir}/b"
+            b_pointer: "{:config_dir}/b"
 
         stacks:
             one:
@@ -151,7 +151,7 @@ describe BespinCase, "Collecting configuration":
             dev:
                 account_id: "123"
                 vars:
-                    a_pointer: "{:this_config_dir}/a"
+                    a_pointer: "{:config_dir}/a"
         """
 
         config3 = """
@@ -164,10 +164,11 @@ describe BespinCase, "Collecting configuration":
 
         stacks:
             one:
-                stack_yaml: "{:this_config_dir}/c"
+                stack_yaml: "{:config_dir}/c"
 
                 vars:
-                    d_pointer: "{:this_config_dir}/d"
+                    d_pointer: "{:config_dir}/d"
+                    e_pointer: "{stacks.one.vars.a_pointer:config_dir}/e"
         """
 
         stack_yaml = """
@@ -181,6 +182,7 @@ describe BespinCase, "Collecting configuration":
               , "b": ""
               , "one":
                 { "a": ""
+                , "e": ""
                 , "envs.yml": dedent(config2)
                 , "two":
                   { "stack.yml": dedent(config3)
@@ -199,6 +201,7 @@ describe BespinCase, "Collecting configuration":
             , "a_pointer": StaticVariable(record["one"]["a"]["/file/"])
             , "b_pointer": StaticVariable(record["b"]["/file/"])
             , "d_pointer": StaticVariable(record["one"]["two"]["d"]["/file/"])
+            , "e_pointer": StaticVariable(record["one"]["e"]["/file/"])
             }
 
         self.assertEqual(stack["vars"](), expected)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -15,6 +15,8 @@ import mock
 import yaml
 import uuid
 import json
+import nose
+import sys
 import os
 
 describe BespinCase, "Collecting configuration":
@@ -120,6 +122,9 @@ describe BespinCase, "Collecting configuration":
             self.assertEqual(environment["staging"].vars.as_dict(), {"one": "ONE"})
 
     it "allows the special this_config_root formatter option to produce the config file where the option is defined":
+        if sys.version.startswith("2.6."):
+            raise nose.SkipTest("Can't have a zero length format field in python2.6")
+
         config1 = """
         ---
         bespin:


### PR DESCRIPTION
An implementation to fix #35 

This required making a change to option_merge to fix the source_for
behaviour
https://github.com/delfick/option_merge/commit/a1b77b85b9961a9965afe3ea94efd10a6785c88e

Here I introduce a this_config_dir format_spec to the formatter that
will find the source for that option in the configuration.

To make this work we must change the stack converter to keep source
information in the object we give to meta (as this object is used when
creating the formatter instance that is used)

I also add a test that ensures that different configs get the correct
value when they say {:this_config_dir}