### PR TITLE
Added support for testing against Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.6"
   - "2.7"
   - "3.5"
+  - "3.6"
 cache:
   directories:
     - $HOME/.pip-cache/


### PR DESCRIPTION
Seeing as AWS Lambda now supports Python 3.6, it would be a good step for the bespin test cases to support this.