### PR TITLE
Improved exception message

### DIFF
--- a/bespin/operations/plan.py
+++ b/bespin/operations/plan.py
@@ -18,7 +18,7 @@ class Plan(object):
                 missing.append(stack)
 
         if missing:
-            raise BadOption("Some stacks in the plan don't exist", missing=missing, available=stacks.keys())
+            raise BadOption("Some stacks in the plan don't exist", missing=missing, available=list(stacks.keys()))
 
         for stack in configuration["plans"][plan]:
             yield stack


### PR DESCRIPTION
was: "Bad option. Some stacks in the plan don't exist"
     available=<generator object iterator_for at 0x102289e60>