### PR TITLE
Add coverage.py to tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+branch = True
+source = bespin/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist/
 .tox/
 docs/_build/
 build/
+.coverage
+htmlcov/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -24,6 +24,11 @@ Then running the tests is::
 .. note:: ``from nose.tools import set_trace; set_trace()`` is your friend and
   will throw you into an interactive debugger.
 
+After tests, a detailed `Coverage.py <http://coverage.readthedocs.io>`_ report can be produced by::
+
+  $ coverage html
+  $ open htmlcov/index.hml
+
 This project heavily uses a couple libraries in particular that are also good
 to ``pip install -e .`` into your virtualenv.
 

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         , "nose"
         , "mock"
         , "moto"
+        , "coverage"
 
         # Need to ensure httpretty is not 0.8.7
         # To prevent an infinite loop in python3 tests

--- a/test.sh
+++ b/test.sh
@@ -1,2 +1,5 @@
-#!/bin/bash
-nosetests --with-noy $@
+#!/bin/bash -e
+coverage erase
+coverage run --branch $(which nosetests) --with-noy "$@"
+coverage report
+# coverage html


### PR DESCRIPTION
I'd like to add code coverage to assist with determining which important code needs more tests.

Prints text output for travis. Developers can produce html or annotated report on their local as per coverage.py docs.