### PR TITLE
Officially support Environment tags

### DIFF
--- a/bespin/option_spec/bespin_specs.py
+++ b/bespin/option_spec/bespin_specs.py
@@ -109,9 +109,6 @@ class copy_environment_spec(Spec):
 
         return BespinSpec().environment_spec.normalise(meta, meta.everything["environments"].as_dict()[val])
 
-class Environment(dictobj):
-    fields = ["account_id", "vars", "region"]
-
 class other_options(dictobj):
     fields = ["run", "create", "build"]
 
@@ -160,7 +157,7 @@ class BespinSpec(object):
     @memoized_property
     def environment_spec(self):
         """Spec for each environment"""
-        return create_spec(Environment
+        return create_spec(stack_objs.Environment
             , account_id = required(or_spec(and_spec(string_spec(), valid_string_spec(validators.regexed("\d+"))), integer_spec()))
             , region = defaulted(string_spec(), "ap-southeast-2")
             , vars = dictionary_spec()
@@ -269,9 +266,9 @@ class BespinSpec(object):
             , stack_name = formatted(defaulted(string_spec(), "{_key_name_1}"), formatter=MergedOptionStringFormatter)
             , environment = formatted(overridden("{environment}"), formatter=MergedOptionStringFormatter)
 
-            , env = listof(stack_specs.env_spec(), expect=stack_objs.Environment)
-            , build_env = listof(stack_specs.env_spec(), expect=stack_objs.Environment)
-            , stack_name_env = listof(stack_specs.env_spec(), expect=stack_objs.Environment)
+            , env = listof(stack_specs.env_spec(), expect=stack_objs.EnvironmentVariable)
+            , build_env = listof(stack_specs.env_spec(), expect=stack_objs.EnvironmentVariable)
+            , stack_name_env = listof(stack_specs.env_spec(), expect=stack_objs.EnvironmentVariable)
 
             # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions
             # Keys = 127 UTF-8 '^aws:' reserved. Values = 255 UTF-8
@@ -346,7 +343,7 @@ class BespinSpec(object):
                 , account_id = required(formatted(string_spec(), formatter=MergedOptionStringFormatter))
                 , application_id = required(formatted(string_spec(), formatter=MergedOptionStringFormatter))
 
-                , env = listof(stack_specs.env_spec(), expect=stack_objs.Environment)
+                , env = listof(stack_specs.env_spec(), expect=stack_objs.EnvironmentVariable)
                 , deployed_version = required(formatted(string_spec(), formatter=MergedOptionStringFormatter))
                 ))
 

--- a/bespin/option_spec/stack_objs.py
+++ b/bespin/option_spec/stack_objs.py
@@ -350,6 +350,9 @@ class Stack(dictobj):
 
         self.validate_template_params()
 
+class Environment(dictobj):
+    fields = ["account_id", "vars", "region"]
+
 class Stackdriver(dictobj):
     fields = {
           "api_key": "The api key used to gain access to stackdriver"
@@ -425,7 +428,7 @@ class DynamicVariable(dictobj):
 
         return outputs[self.output]
 
-class Environment(dictobj):
+class EnvironmentVariable(dictobj):
     """A single environment variable, and it's default or set value"""
     fields = ["env_name", ("default_val", None), ("set_val", None)]
 

--- a/bespin/option_spec/stack_objs.py
+++ b/bespin/option_spec/stack_objs.py
@@ -351,7 +351,16 @@ class Stack(dictobj):
         self.validate_template_params()
 
 class Environment(dictobj):
-    fields = ["account_id", "vars", "region"]
+    fields = {
+          "account_id": "AWS account id for this environment"
+        , "vars": "A dictionary of variable definitions that may be referred to in other parts of the configuration"
+        , "region": "AWS region name for this environment"
+        , "tags": """
+              A dictionary specifying the tags to apply to the stack
+
+              Cloudformation will apply these tags to all created resources
+          """
+    }
 
 class Stackdriver(dictobj):
     fields = {

--- a/bespin/option_spec/stack_specs.py
+++ b/bespin/option_spec/stack_specs.py
@@ -6,7 +6,7 @@ options.
 """
 
 from bespin.option_spec.stack_objs import (
-      StaticVariable, DynamicVariable, Environment, Skipper, S3Address
+      StaticVariable, DynamicVariable, EnvironmentVariable, Skipper, S3Address
     , UltraDNSSite, UltraDNSProvider
     )
 from bespin.option_spec.artifact_objs import ArtifactCommand
@@ -52,7 +52,7 @@ class env_spec(many_item_formatted_spec):
     seperators = [':', '=']
 
     specs = [sb.string_spec()]
-    creates = Environment
+    creates = EnvironmentVariable
     optional_specs = [sb.string_or_int_as_string_spec()]
     formatter = MergedOptionStringFormatter
 
@@ -67,7 +67,7 @@ class env_spec(many_item_formatted_spec):
             args.extend([other_val, None])
         elif dividers[0] == '=':
             args.extend([None, other_val])
-        return Environment(*args)
+        return EnvironmentVariable(*args)
 
 class skipper_spec(many_item_formatted_spec):
     value_name = "Skip specification"

--- a/docs/sphinx/ext/show_specs.py
+++ b/docs/sphinx/ext/show_specs.py
@@ -11,11 +11,16 @@ import six
 class ShowSpecsDirective(Directive):
     """Directive for outputting all the specs found in bespin.option_spec.bespin_spec"""
     has_content = True
+    specs = [
+          ("Bespin", BespinSpec().bespin_spec)
+        , ("Stack", BespinSpec().stack_spec)
+        , ("Environment", BespinSpec().environment_spec)
+    ]
 
     def run(self):
         """For each file in noseOfYeti/specs, output nodes to represent each spec file"""
         tokens = []
-        for name, spec in (("Bespin", BespinSpec().bespin_spec), ("Stack", BespinSpec().stack_spec)):
+        for name, spec in self.specs:
             section = nodes.section()
             section['names'].append(name)
             section['ids'].append(name)

--- a/tests/option_spec/objs/test_simple.py
+++ b/tests/option_spec/objs/test_simple.py
@@ -28,13 +28,13 @@ describe BespinCase, "Dynamic Variable":
             var = objs.DynamicVariable(stack, output)
             self.assertIs(var.resolve(), resolved)
 
-describe BespinCase, "Environment":
+describe BespinCase, "EnvironmentVariable":
     before_each:
         self.env_name = self.unique_val()
         self.fallback_val = self.unique_val()
 
     it "defaults default_val and set_val to None":
-        env = objs.Environment(self.env_name)
+        env = objs.EnvironmentVariable(self.env_name)
         self.assertIs(env.default_val, None)
         self.assertIs(env.set_val, None)
 
@@ -46,17 +46,17 @@ describe BespinCase, "Environment":
 
             it "returns env_name and default_val if we have a default_val":
                 for val in (self.fallback_val, ""):
-                    env = objs.Environment(self.env_name, val, None)
+                    env = objs.EnvironmentVariable(self.env_name, val, None)
                     self.assertEqual(env.pair, (self.env_name, val))
 
             it "returns env_name and set_val if we have a set_val":
                 for val in (self.fallback_val, ""):
-                    env = objs.Environment(self.env_name, None, val)
+                    env = objs.EnvironmentVariable(self.env_name, None, val)
                     self.assertEqual(env.pair, (self.env_name, val))
 
             it "complains if we have no default_val":
                 with self.fuzzyAssertRaisesError(KeyError, self.env_name):
-                    env = objs.Environment(self.env_name)
+                    env = objs.EnvironmentVariable(self.env_name)
                     env.pair
 
         describe "Env name is in environment":
@@ -68,14 +68,14 @@ describe BespinCase, "Environment":
                 del os.environ[self.env_name]
 
             it "returns the value from the environment if default_val is set":
-                env = objs.Environment(self.env_name, self.fallback_val, None)
+                env = objs.EnvironmentVariable(self.env_name, self.fallback_val, None)
                 self.assertEqual(env.pair, (self.env_name, self.env_val))
 
             it "returns the set_val if set_val is set":
-                env = objs.Environment(self.env_name, None, self.fallback_val)
+                env = objs.EnvironmentVariable(self.env_name, None, self.fallback_val)
                 self.assertEqual(env.pair, (self.env_name, self.fallback_val))
 
             it "returns the value from the environment if no default or set val":
-                env = objs.Environment(self.env_name)
+                env = objs.EnvironmentVariable(self.env_name)
                 self.assertEqual(env.pair, (self.env_name, self.env_val))
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,7 +1,7 @@
 # coding: spec
 
-from bespin.option_spec.bespin_specs import Bespin, Environment
-from bespin.option_spec.stack_objs import Stack, StaticVariable
+from bespin.option_spec.bespin_specs import Bespin
+from bespin.option_spec.stack_objs import Stack, StaticVariable, Environment
 from bespin.option_spec.task_objs import Task
 from bespin.collector import Collector
 


### PR DESCRIPTION
Also refactors Environment classes. stack_objs.Environment was actually used for EnvironmentVariable whereas bespin_spec.Environment was used for Environment.

Relates #34