### PR TITLE
Add 'count' formatter

### DIFF
--- a/bespin/formatter.py
+++ b/bespin/formatter.py
@@ -79,6 +79,10 @@ class MergedOptionStringFormatter(StringFormatter):
         elif format_spec == "date":
             return datetime.now().strftime(obj)
 
+        elif format_spec == "count":
+            cdl = map(str.strip, obj.split(","))
+            return str(len(cdl))
+
         elif format_spec == "config_dir":
             path = self.option_path
             if obj:

--- a/bespin/formatter.py
+++ b/bespin/formatter.py
@@ -19,6 +19,7 @@ from bespin.errors import BadOptionFormat
 from input_algorithms.meta import Meta
 
 from datetime import datetime
+import six
 import os
 
 class MergedOptionStringFormatter(StringFormatter):
@@ -80,8 +81,13 @@ class MergedOptionStringFormatter(StringFormatter):
             return datetime.now().strftime(obj)
 
         elif format_spec == "count":
-            cdl = map(str.strip, obj.split(","))
-            return str(len(cdl))
+            if isinstance(obj, six.string_types):
+                obj = obj.split(",")
+
+            if isinstance(obj, list):
+                return str(len(obj))
+            else:
+                raise BadOptionFormat("Can only :count 'list' or comma delimited 'str' type", option_path=self.option_path, got=obj)
 
         elif format_spec == "config_dir":
             path = self.option_path

--- a/docs/docs/configuration.rst
+++ b/docs/docs/configuration.rst
@@ -159,11 +159,12 @@ Available formatters include:
   Converts '-' to '_'.
 
 :count
-  Returns the total number of string elements in a CommaDelimitedList variable
-  as a string. The total number of strings should be one more than the total
-  number of commas. This implementation marries `Cloudformation Parameters`_
-  CommaDelimitedList's implementation.
-  Examples::
+  Returns the total number of elements in a list or CommaDelimitedList variable
+  as a string.
+
+  The total number of elements in a CommaDelimitedList should be one more than
+  the total number of commas. This implementation marries `Cloudformation
+  Parameters`_ CommaDelimitedList's implementation.  Examples::
 
       vars:
         one: "1"        # {one:count} == "1"

--- a/docs/docs/configuration.rst
+++ b/docs/docs/configuration.rst
@@ -158,6 +158,23 @@ Available formatters include:
 :underscored
   Converts '-' to '_'.
 
+:count
+  Returns the total number of string elements in a CommaDelimitedList variable
+  as a string. The total number of strings should be one more than the total
+  number of commas. This implementation marries `Cloudformation Parameters`_
+  CommaDelimitedList's implementation.
+  Examples::
+
+      vars:
+        one: "1"        # {one:count} == "1"
+        two: "1,2"      # {two:count} == "2"
+        three: "1,2,3"  # {three:count} == "3"
+        empty: ""       # {empty:count} == "1"
+        space: " "      # {space:count} == "1"
+        comma: ","      # {comma:count} == "2"
+
+.. _Cloudformation Parameters: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html
+
 .. note:: The formatter does not support nested values (eg: {a.{foo}.c}). See
    :doc:`stacks` for details on using variable formatting (ie: XXX_MYVAR_XXX)
    instead.

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -65,3 +65,26 @@ describe BespinCase, "MergedOptionStringFormatter":
         expected = datetime.now().strftime("%Y%b")
         self.check_formatting({}, [], value="{%Y%b:date}", expected=expected)
 
+    it "can count CommaDelimitedList":
+        conf = {
+              "one": "1"        # ['1']
+            , "two": "a,b"      # ['a','b']
+            , "three": "1,2,3"  # ['1','2','3']
+            , "empty": ""       # ['']
+            , "space": " "      # ['']
+            , "comma": ","      # ['','']
+            , "comspc": "  , "  # ['','']
+            , "long": " spaces  ,are  ,    trimed " # ['spaces','are','trimed']
+        }
+        self.check_formatting(conf, [], value="{one:count}", expected="1")
+        self.check_formatting(conf, [], value="{two:count}", expected="2")
+        self.check_formatting(conf, [], value="{three:count}", expected="3")
+
+        self.check_formatting(conf, [], value="{empty:count}", expected="1")
+        self.check_formatting(conf, [], value="{space:count}", expected="1")
+
+        self.check_formatting(conf, [], value="{comma:count}", expected="2")
+        self.check_formatting(conf, [], value="{comspc:count}", expected="2")
+
+        self.check_formatting(conf, [], value="{long:count}", expected="3")
+

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -88,3 +88,24 @@ describe BespinCase, "MergedOptionStringFormatter":
 
         self.check_formatting(conf, [], value="{long:count}", expected="3")
 
+    it "can count lists":
+        conf = {
+              "one": [1]
+            , "two": [1,2]
+            , "three": [1,2,3]
+            , "empty": []
+            , "nestedone": [[]]
+            , "nestedtwo": [[1],2]
+            , "nestedthree": [[1],2,[3,4]]
+            , "bad": {}
+        }
+        self.check_formatting(conf, [], value="{one:count}", expected="1")
+        self.check_formatting(conf, [], value="{two:count}", expected="2")
+        self.check_formatting(conf, [], value="{three:count}", expected="3")
+        self.check_formatting(conf, [], value="{empty:count}", expected="0")
+        self.check_formatting(conf, [], value="{nestedone:count}", expected="1")
+        self.check_formatting(conf, [], value="{nestedtwo:count}", expected="2")
+        self.check_formatting(conf, [], value="{nestedthree:count}", expected="3")
+
+        with self.fuzzyAssertRaisesError(BadOptionFormat, "Can only :count 'list' or comma delimited 'str' type", got=conf['bad']):
+            self.check_formatting(conf, [], value="{bad:count}", expected="error")


### PR DESCRIPTION
Returns array length of CommaDelimitedList.

Was originally going to return `{var:count} == 0` for `var: ""` (after strip), but decided to match CloudFormation as close as possible. Passing empty string to CloudFormation CommaDelimitedList results in `['']` such that `!Select [ 0, !Ref param ]` returns `''`.

Open to discussing name. Originally thought of 'length' but `{var:length}` to me means string length. Any other ideas seemed long or clunky. 