### PR TITLE
Update for moto 1.0

### DIFF
--- a/tests/amazon/test_sqs.py
+++ b/tests/amazon/test_sqs.py
@@ -13,12 +13,12 @@ import sys
 
 if sys.version_info[0] == 2 and sys.version_info[1] == 6:
     # This can be removed when we can use latest Httpretty again
-    def mock_sqs(func):
+    def mock_sqs_deprecated(func):
         def wrapped(*args):
             raise nose.SkipTest("No moto support for python2.6 atm")
         return wrapped
 else:
-    from moto import mock_sqs
+    from moto import mock_sqs_deprecated
 
 describe BespinCase, "Decode Message":
     it "successfully decode a valid message":
@@ -91,7 +91,7 @@ describe BespinCase, "SQS":
             self.assertEqual(sleeps, [2, 2, 2])
             self.assertEqual(queue.delete_message.mock_calls, [mock.call(message1), mock.call(message2), mock.call(message3)])
 
-        @mock_sqs
+        @mock_sqs_deprecated
         it "works with the sqs api":
             conn = boto.connect_sqs()
             sqs = SQS()

--- a/tests/option_spec/objs/test_artifact_objs.py
+++ b/tests/option_spec/objs/test_artifact_objs.py
@@ -20,12 +20,12 @@ import os
 
 if sys.version_info[0] == 2 and sys.version_info[1] == 6:
     # This can be removed when we can use latest Httpretty again
-    def mock_s3(func):
+    def mock_s3_deprecated(func):
         def wrapped(*args):
             raise nose.SkipTest("No moto support for python2.6 atm")
         return wrapped
 else:
-    from moto import mock_s3
+    from moto import mock_s3_deprecated
 
 optional_any = lambda: sb.optional_spec(sb.any_spec())
 artifact_spec = sb.create_spec(Artifact
@@ -39,7 +39,7 @@ artifact_spec = sb.create_spec(Artifact
 
 describe BespinCase, "ArtifactCollection":
     describe "clean_old_artifacts":
-        @mock_s3
+        @mock_s3_deprecated
         it "does nothing if dry_run is True":
             s3 = S3()
             conn = s3.conn = boto.connect_s3()
@@ -60,7 +60,7 @@ describe BespinCase, "ArtifactCollection":
                 , sorted(["stuff/one.tar.gz", "stuff/two.tar.gz", "stuff/three.tar.gz", "stuff/four.tar.gz"])
                 )
 
-        @mock_s3
+        @mock_s3_deprecated
         it "Deletes the oldest such that only history_length is left":
             s3 = S3()
             conn = s3.conn = boto.connect_s3()


### PR DESCRIPTION
Moto 1.0 deprecated support for boto.
Changed all test decorators for bespin functionality which has not yet
been ported to boto3.
Relates #17