### PR TITLE
Unpin paramiko

### DIFF
--- a/bespin/operations/ssh.py
+++ b/bespin/operations/ssh.py
@@ -45,7 +45,6 @@ class SSH(object):
     def run(self):
         jb = None
         defaults = config.load_default_settings()
-        defaults['hostkey.verify'] = 'ignore'
 
         original_paramiko_agent = paramiko.Agent
         with hp.a_temp_file() as fle:

--- a/docs/docs/ssh.rst
+++ b/docs/docs/ssh.rst
@@ -5,6 +5,11 @@ SSH'ing into instances
 
 It's useful to be able to ssh into instances that your bring up in your stack.
 
+.. note:: bespin uses RadSSH which honours ``ssh_config(5)`` (ie: ~/.ssh/config).
+   Users may want to set ``StrictHostKeyChecking no`` to ignore hostkeys and/or
+   ``UserKnownHostsFile /dev/null`` to prevent host key additions for
+   dynamic/cloud instances.
+
 Bespin provides the ``instances`` command for finding the instances, getting the
 ssh key, and ssh'ing into one of the instances.
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
       , "humanize"
       , "argparse"
       , "requests"
-      , "paramiko==1.16.0"
+      , "paramiko"
 
       , "radssh==1.0.5"
       , "pyrelic==0.8.0"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
       , "requests"
       , "paramiko"
 
-      , "radssh==1.0.5"
+      , "radssh==1.1.1"
       , "pyrelic==0.8.0"
       , "boto==2.40.0"
       , "boto3"


### PR DESCRIPTION
paramiko 1.x relies on insecure dependencies

Was previously pinned in 7566e1fe - unsure why.