### PR TITLE
Update dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
       , "boto3==1.5.20"
       , "pyYaml==3.12"
       , "ultra_rest_client==0.1.4"
-      , "FileChunkIO==1.6"
       , "dnslib==0.9.4"
       ]
 

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ setup(
 
       , "radssh==1.1.1"
       , "pyrelic==0.8.0"
-      , "boto==2.40.0"
-      , "boto3==1.4.7"
-      , "pyYaml==3.10"
+      , "boto==2.48.0"
+      , "boto3==1.5.20"
+      , "pyYaml==3.12"
       , "ultra_rest_client==0.1.4"
       , "FileChunkIO==1.6"
       , "dnslib==0.9.4"


### PR DESCRIPTION
Is there any reason why these are hard pinned? Could they be relaxed to "up to same major"?